### PR TITLE
recursively logging dependencies

### DIFF
--- a/can-debug-test.js
+++ b/can-debug-test.js
@@ -1,8 +1,139 @@
 import QUnit from 'steal-qunit';
-import plugin from './can-debug';
+import debug from './can-debug';
+
+import canSymbol from 'can-symbol';
+import CIDSet from 'can-util/js/cid-set/cid-set';
+import CIDMap from 'can-util/js/cid-map/cid-map';
+
+import Observation from 'can-observation';
+import canEvent from 'can-event';
+import assign from 'can-util/js/assign/assign';
+import CID from 'can-cid';
+
+function MockObservation(cid, keyDeps, valueDeps) {
+  this._cid = cid;
+  var valueDependencies = new CIDSet();
+  var keyDependencies = new CIDMap();
+
+  valueDeps.forEach(function(valueDep) {
+    valueDependencies.add(valueDep);
+  });
+
+  for (var key in keyDeps) {
+    keyDependencies.set(keyDeps[key], [ key ]);
+  }
+
+  this[canSymbol.for('can.getValueDependencies')] = function() {
+    return {
+      valueDependencies: valueDependencies,
+      keyDependencies: keyDependencies
+    };
+  };
+
+  this[canSymbol.for('can.getValue')] = function() {
+    return 'value-' + cid;
+  };
+}
 
 QUnit.module('can-debug');
 
-QUnit.test('exports a function', function(){
-  QUnit.equal(typeof plugin, 'function');
+QUnit.test('basics', function() {
+  var keyDepKeyDep = new MockObservation('keyDepKeyDep', {}, []);
+  var keyDepValueDep = new MockObservation('keyDepValueDep', {}, []);
+  var keyDep = new MockObservation('keyDep', {
+    keyDepKeyDep: keyDepKeyDep
+  }, [
+    keyDepValueDep
+  ]);
+
+  var valueDepKeyDep = new MockObservation('valueDepKeyDep', {}, []);
+  var valueDepValueDep = new MockObservation('valueDepValueDep', {}, []);
+  var valueDep = new MockObservation('valueDep', {
+    valueDepKeyDep: valueDepKeyDep
+  }, [
+    valueDepValueDep
+  ]);
+
+  var obs = new MockObservation('obs', { keyDep: keyDep }, [ valueDep ]);
+
+  var debugData = debug(obs);
+
+  QUnit.deepEqual(debugData, {
+    cid: 'obs',
+    obj: obs,
+    value: 'value-obs',
+    valueDependencies: [{
+      cid: 'valueDep',
+      obj: valueDep,
+      value: 'value-valueDep',
+      valueDependencies: [{
+        cid: 'valueDepValueDep',
+        obj: valueDepValueDep,
+        value: 'value-valueDepValueDep',
+        valueDependencies: [],
+        keyDependencies: {}
+      }],
+      keyDependencies: {
+        valueDepKeyDep: {
+          cid: 'valueDepKeyDep',
+          obj: valueDepKeyDep,
+          value: 'value-valueDepKeyDep',
+          valueDependencies: [],
+          keyDependencies: {}
+        }
+      }
+    }],
+    keyDependencies: {
+      keyDep: {
+        cid: 'keyDep',
+        obj: keyDep,
+        value: 'value-keyDep',
+        valueDependencies: [{
+          cid: 'keyDepValueDep',
+          obj: keyDepValueDep,
+          value: 'value-keyDepValueDep',
+          valueDependencies: [],
+          keyDependencies: {}
+        }],
+        keyDependencies: {
+          keyDepKeyDep: {
+            cid: 'keyDepKeyDep',
+            obj: keyDepKeyDep,
+            value: 'value-keyDepKeyDep',
+            valueDependencies: [],
+            keyDependencies: {}
+          }
+        }
+      }
+    }
+  });
+});
+
+QUnit.test('works with can-observation', function() {
+	var obs1 = assign({prop1: 1}, canEvent);
+  CID(obs1);
+
+  var obs2 = function() {
+    return 2;
+  };
+  CID(obs2);
+  obs2[canSymbol.for('can.onValue')] = function() {};
+  obs2[canSymbol.for('can.offValue')] = function() {};
+  obs2[canSymbol.for('can.getValue')] = function() {
+    return this();
+  };
+
+	var observation = new Observation(function() {
+		Observation.add(obs1, 'prop1');
+		Observation.add(obs2);
+		return obs1.prop1 + obs2();
+	});
+	observation.start();
+
+  try {
+    debug(observation);
+    QUnit.ok(true, 'should not throw');
+  } catch(e) {
+    QUnit.ok(false, e);
+  }
 });

--- a/can-debug.js
+++ b/can-debug.js
@@ -1,6 +1,35 @@
 var namespace = require('can-namespace');
+var canSymbol = require('can-symbol');
+var canReflect = require('can-reflect');
 
-function debug() {
+var getValueDependenciesSymbol = canSymbol.for('can.getValueDependencies');
+
+function debug(obj) {
+  var debugData = {
+    cid: obj._cid,
+    obj: obj,
+    value: canReflect.getValue(obj),
+    valueDependencies: [],
+    keyDependencies: {}
+  };
+
+  if (obj[getValueDependenciesSymbol]) {
+    var deps = canReflect.getValueDependencies(obj) || {};
+
+    if (deps.valueDependencies) {
+      deps.valueDependencies.forEach(function(valueDep) {
+        debugData.valueDependencies.push( debug(valueDep) );
+      });
+    }
+
+    if (deps.keyDependencies) {
+      deps.keyDependencies.forEach(function(events, key) {
+        debugData.keyDependencies[events.join(',')] = debug(key);
+      });
+    }
+  }
+
+  return debugData;
 }
 
 module.exports = namespace.debug = debug;

--- a/package.json
+++ b/package.json
@@ -35,9 +35,6 @@
     "npmIgnore": [
       "testee",
       "steal-tools"
-    ],
-    "plugins": [
-      "steal-stache"
     ]
   },
   "dependencies": {
@@ -46,16 +43,11 @@
     "can-symbol": "^1.0.0"
   },
   "devDependencies": {
-    "can-component": "^3.0.7",
-    "can-define": "^1.0.17",
-    "can-stache": "^3.0.20",
-    "can-stache-bindings": "^3.4.0",
-    "can-stache-converters": "^3.2.0",
-    "can-view-autorender": "^3.0.4",
+    "can-event": "^3.5.0",
+    "can-observation": "^3.3.1",
     "jshint": "^2.9.1",
     "steal": "^1.3.1",
     "steal-qunit": "^1.0.1",
-    "steal-stache": "^3.0.5",
     "steal-tools": "^1.2.0",
     "testee": "^0.6.1"
   },

--- a/test.html
+++ b/test.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <title>can-debug</title>
 <script src="node_modules/steal/steal.js" main="can-debug/can-debug-test"></script>
 <div id="qunit-fixture"></div>


### PR DESCRIPTION
Closes https://github.com/canjs/can-debug/issues/1.

Took a stab at this. We'll probably have to refine over time as more things implement `getValueDependencies` in useful ways.