### PR TITLE
Get logWhatChangesMe to work with simple-observable/*

### DIFF
--- a/can-debug.js
+++ b/can-debug.js
@@ -6,7 +6,7 @@ var getKeyDependenciesSymbol = canSymbol.for('can.getKeyDependencies');
 var getValueDependenciesSymbol = canSymbol.for('can.getValueDependencies');
 
 function debug(obj, key) {
-	// key can be 0, maybe undefined
+	// key can be 0, an empty string, maybe undefined.
 	var gotKey = arguments.length === 2;
 
 	var data = {
@@ -43,6 +43,9 @@ function debug(obj, key) {
 }
 
 debug.logWhatChangesMe = function(obj, key) {
+	// key can be 0, an empty string, maybe undefined.
+	var gotKey = arguments.length === 2;
+
 	var quoteString = function(x) {
 		return typeof x === 'string' ? JSON.stringify(x) : x;
 	};
@@ -58,7 +61,7 @@ debug.logWhatChangesMe = function(obj, key) {
 		console.groupEnd();
 	};
 
-	log(debug(obj, key));
+	return gotKey ? log(debug(obj, key)) : log(debug(obj));
 };
 
 function getKeyDependencies(obj, key) {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "can-define": "^2.0.0-pre.0",
     "can-observation": "^4.0.0-pre.0",
-    "can-simple-observable": "^2.0.0-pre.13",
+    "can-simple-observable": "^2.0.0-pre.14",
     "jshint": "^2.9.1",
     "steal": "^1.3.1",
     "steal-qunit": "^1.0.1",


### PR DESCRIPTION
**Needs a new release of can-simple-observable**

The following observable:

```js
var value = new SimpleObservable(2);

var obs = new SettableObservable(
  function(lastSet) {
    return lastSet * value.get();
  },
  null,
  1
);
```

logs the following:

![screen shot 2017-10-24 at 10 33 05](https://user-images.githubusercontent.com/724877/31956065-8d7fba3a-b8a7-11e7-81a2-cdbfe552cc4f.png)
