### PR TITLE
Get logWhatChangesMe to work with scope/compute-data

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,9 @@
   "devDependencies": {
     "can-define": "^2.0.0-pre.0",
     "can-observation": "^4.0.0-pre.0",
+    "can-simple-map": "^4.0.0-pre.6",
     "can-simple-observable": "^2.0.0-pre.14",
+    "can-view-scope": "^4.0.0-pre.21",
     "jshint": "^2.9.1",
     "steal": "^1.3.1",
     "steal-qunit": "^1.0.1",


### PR DESCRIPTION
`can-view-scope/compute-data` was working already. 

This code

```js
var Person = DefineMap.extend("Person", {
  first: "string",
  last: "string",
  fullName: {
    get: function() {
      return this.first + " " + this.last;
    }
  }
});

var map = new Person({ first: "John", last: "Doe" });
var scope = new Scope(map);
var computeData = scope.computeData("fullName");
computeData.compute.bind("change", noop);

debug.logWhatChangesMe(computeData);
```

Generates the following output:

![screen shot 2017-10-24 at 13 57 48](https://user-images.githubusercontent.com/724877/31965602-16c898f8-b8c5-11e7-85cf-678c1882567b.png)

cc: @justinbmeyer 