### PR TITLE
Use a blockquote for the "Note" section

### DIFF
--- a/doc/can-debug.md
+++ b/doc/can-debug.md
@@ -93,10 +93,10 @@ The whole output can be read as:
 `Person{}.fullName` derives its value from `Observation<Person{}'s fullName getter>`,
 which in turn derive its value from `Person{}.first` and `Person{}.last` values.
 
-**NOTE**: Please keep in mind that some of the observables printed out in the console 
-do not necessarily match the ones found in user's application code, as mentioned 
-before, observables used internally are listed as dependencies, such is the case 
-of `Observation<Person{}'s fullName getter>` in the example.
+> Note: Please keep in mind that some of the observables printed out in the console 
+> do not necessarily match the ones found in user's application code, as mentioned 
+> before, observables used internally are listed as dependencies, such is the case 
+> of `Observation<Person{}'s fullName getter>` in the example.
 
 The following demos a live version of the previous example, click the `logWhatChangesMe`
 button and open the browser's console tab to inspect the generated message:


### PR DESCRIPTION
It looks a lot better and it's consistent with other CanJS doc pages

![screen shot 2017-12-13 at 1 28 31 pm](https://user-images.githubusercontent.com/724877/33960952-99554d6e-e009-11e7-869e-f6b78b4524f0.png)