### PR TITLE
 Export can namespace with warning on access

### DIFF
--- a/can-debug-test.js
+++ b/can-debug-test.js
@@ -1,11 +1,33 @@
-require("can-debug/src/graph/graph-test");
-require("can-debug/src/get-data/get-data-test");
-require("can-debug/src/get-graph/get-graph-test");
-require("can-debug/src/label-cycles/label-cycles-test");
+var QUnit = require("steal-qunit");
+var debug = require("can-debug");
 
-require("can-debug/src/log-data/log-data-test");
-require("can-debug/src/what-i-change/what-i-change");
-require("can-debug/src/what-changes-me/what-changes-me-test");
-require("can-debug/src/get-what-i-change/get-what-i-change-test");
-require("can-debug/src/get-what-changes-me/get-what-changes-me-test");
+QUnit.module("can-debug");
 
+QUnit.test("exports an object", function(assert) {
+	assert.equal(typeof debug, "object", "should set global namespace");
+	assert.equal(typeof debug.logWhatChangesMe, "function");
+	assert.equal(typeof debug.logWhatChangesMe, "function");
+});
+
+QUnit.test("sets can global namespace", function(assert) {
+	assert.equal(typeof window.can, "object", "should set global namespace");
+});
+
+QUnit.test("warns users accessing global namespace once", function(assert) {
+	var warn = console.warn;
+
+	assert.expect(1);
+	console.warn = function(msg) {
+		assert.ok(/for debugging purposes only/.test(msg));
+	};
+
+	var d = can.debug;
+	d = can.debug;
+	d = can.debug;
+
+	console.warn = warn;
+});
+
+QUnit.test("sets itself on the global namespace", function(assert) {
+	assert.equal(typeof can.debug, "object", "should set itself");
+});

--- a/can-debug-test.js
+++ b/can-debug-test.js
@@ -13,20 +13,22 @@ QUnit.test("sets can global namespace", function(assert) {
 	assert.equal(typeof window.can, "object", "should set global namespace");
 });
 
-QUnit.test("warns users accessing global namespace once", function(assert) {
-	var warn = console.warn;
+(Proxy != null ? QUnit.test : QUnit.skip)("warns users accessing global namespace once",
+	function(assert) {
+		var warn = console.warn;
 
-	assert.expect(1);
-	console.warn = function(msg) {
-		assert.ok(/for debugging purposes only/.test(msg));
-	};
+		assert.expect(1);
+		console.warn = function(msg) {
+			assert.ok(/for debugging purposes only/.test(msg));
+		};
 
-	var d = can.debug;
-	d = can.debug;
-	d = can.debug;
+		var d = can.debug;
+		d = can.debug;
+		d = can.debug;
 
-	console.warn = warn;
-});
+		console.warn = warn;
+	}
+);
 
 QUnit.test("sets itself on the global namespace", function(assert) {
 	assert.equal(typeof can.debug, "object", "should set itself");

--- a/can-debug.js
+++ b/can-debug.js
@@ -1,4 +1,5 @@
 var namespace = require("can-namespace");
+var proxyNamespace = require("./src/proxy-namespace");
 
 var logWhatIChange = require("./src/what-i-change/what-i-change");
 var logWhatChangesMe = require("./src/what-changes-me/what-changes-me");
@@ -12,13 +13,4 @@ module.exports = namespace.debug = {
 	logWhatChangesMe: logWhatChangesMe
 };
 
-var warned = false;
-window.can = new Proxy(namespace, {
-	get: function get(target, name) {
-		if (!warned) {
-			console.warn("Warning: use of 'can' global should be for debugging purposes only.");
-			warned = true;
-		}
-		return target[name];
-	}
-});
+window.can = Proxy != null ? proxyNamespace(namespace) : namespace;

--- a/can-debug.js
+++ b/can-debug.js
@@ -11,3 +11,14 @@ module.exports = namespace.debug = {
 	logWhatIChange: logWhatIChange,
 	logWhatChangesMe: logWhatChangesMe
 };
+
+var warned = false;
+window.can = new Proxy(namespace, {
+	get: function get(target, name) {
+		if (!warned) {
+			console.warn("Warning: use of 'can' global should be for debugging purposes only.");
+			warned = true;
+		}
+		return target[name];
+	}
+});

--- a/src/proxy-namespace.js
+++ b/src/proxy-namespace.js
@@ -1,0 +1,13 @@
+var warned = false;
+
+module.exports = function proxyNamescape(namespace) {
+	return new Proxy(namespace, {
+		get: function get(target, name) {
+			if (!warned) {
+				console.warn("Warning: use of 'can' global should be for debugging purposes only.");
+				warned = true;
+			}
+			return target[name];
+		}
+	});
+};

--- a/test.html
+++ b/test.html
@@ -6,6 +6,6 @@
 </head>
 <body>
 	<div id="qunit-fixture"></div>
-	<script src="node_modules/steal/steal.js" main="can-debug/can-debug-test"></script>
+	<script src="node_modules/steal/steal.js" main="can-debug/test"></script>
 </body>
 </html>

--- a/test.js
+++ b/test.js
@@ -1,0 +1,12 @@
+require("can-debug/can-debug-test");
+require("can-debug/src/graph/graph-test");
+require("can-debug/src/get-data/get-data-test");
+require("can-debug/src/get-graph/get-graph-test");
+require("can-debug/src/label-cycles/label-cycles-test");
+
+require("can-debug/src/log-data/log-data-test");
+require("can-debug/src/what-i-change/what-i-change");
+require("can-debug/src/what-changes-me/what-changes-me-test");
+require("can-debug/src/get-what-i-change/get-what-i-change-test");
+require("can-debug/src/get-what-changes-me/get-what-changes-me-test");
+


### PR DESCRIPTION
Closes #29

![screen shot 2017-12-19 at 9 56 23 am](https://user-images.githubusercontent.com/724877/34171596-1af9f864-e4ac-11e7-9db2-5362c5276682.png)

Also @justinbmeyer, I was able to conditionally load it in webpack like:

```js
if (process.env.NODE_ENV !== "production") {
  import("can-debug");
}
```

```js
// config
var path = require("path");
var webpack = require("webpack");

module.exports = {
  entry: "./src/index.js",
  output: {
    filename: "bundle.js",
    path: path.resolve(__dirname, "dist")
  },
  plugins: [
    new webpack.DefinePlugin({
      "process.env": {
        NODE_ENV: JSON.stringify("production")
      }
    })
  ]
};
```

I wasn't sure why we discussed making it so `can-debug` does not set the namespace to `window` but to let users do it... What am I missing?