### PR TITLE
Adjust public API and fix image overflow

### DIFF
--- a/doc/can-debug.md
+++ b/doc/can-debug.md
@@ -14,8 +14,7 @@ Exports an object with the following methods:
 
 ```js
 {
-	getGraph         // Get the observable dependency graph
-	getDebugData     // Get the observable dependencies as a deeply nested object
+	drawGraph        // Draws the dependency graph in a new window
 	logWhatIChange   // Log what the observable affects
 	logWhatChangesMe // Log what affects the observable
 }
@@ -48,13 +47,13 @@ debug.logWhatChangesMe(me, "fullName");
 
 Which prints out the following message to the browser's console:
 
-![logWhatChangesMe full output](../node_modules/can-debug/doc/what-changes-me-full.png)
+<img class="bit-docs-screenshot" alt="logWhatchangesMe full output" src="../node_modules/can-debug/doc/what-changes-me-full.png">
 
 At first, the message might be very confusing, specially so in larger examples 
 where multiple observables are involved. Let's break it up in smaller sections to 
 get a better understanding of what each means:
 
-![logWhatChangesMe output](../node_modules/can-debug/doc/what-changes-me-top.png)
+<img class="bit-docs-screenshot" alt="logWhatchangesMe output" src="../node_modules/can-debug/doc/what-changes-me-top.png">
 
 The following values are printed out for each observable in the dependency graph:
 
@@ -82,7 +81,7 @@ The observables in each group are printed out recursively using the same format 
 just described, We can can confirm this by expanding `Person{}.fullName`'s dependencies 
 group:
 
-![logWhatChangesMe dependencies](../node_modules/can-debug/doc/what-changes-me-deps.png)
+<img class="bit-docs-screenshot" alt="dependencies" src="../node_modules/can-debug/doc/what-changes-me-deps.png">
 
 The whole output can be read as:
 
@@ -135,7 +134,7 @@ debug.logWhatChangeMe(document.querySelect("#full"));
 
 This prints out the following message:
 
-![logWhatChangesMe dependencies](../node_modules/can-debug/doc/what-changes-me-input.png)
+<img class="bit-docs-screenshot" alt="logWhatChangesMe" src="../node_modules/can-debug/doc/what-changes-me-input.png">
 
 That's a long message! but once you have identified the output pattern, making sense 
 of it is a lot easier. The observables highlighted in blue border boxes are the most 

--- a/doc/draw-graph.md
+++ b/doc/draw-graph.md
@@ -40,7 +40,7 @@ debug.drawGraph(me, "fullName");
 
 Calling `debug.drawGraph` opens up a new browser window like this:
 
-![dependencyGraph](../node_modules/can-debug/doc/map-dependency-graph.png)
+<img class="bit-docs-screenshot" alt="dependencyGraph" src="../node_modules/can-debug/doc/map-dependency-graph.png">
 
 @param {Object} observable An observable.
 @param {Any} [key] The key of a property on a map-like observable.

--- a/doc/log-what-changes-me.md
+++ b/doc/log-what-changes-me.md
@@ -32,7 +32,7 @@ debug.logWhatChangesMe(me, "fullName");
 Calling `logWhatChangesMe` prints out the following message to the browser's 
 console:
 
-![logWhatChangesMe full output](../node_modules/can-debug/doc/what-changes-me-full.png)
+<img class="bit-docs-screenshot" alt="logWhatChangesMe" src="../node_modules/can-debug/doc/what-changes-me-full.png">
 
 @param {Object} observable An observable.
 @param {Any} [key] The key of a property on a map-like observable.

--- a/doc/log-what-i-change.md
+++ b/doc/log-what-i-change.md
@@ -47,7 +47,7 @@ debug.logWhatIChange(document.querySelector("#first"), "value");
 It logs the observables affected by the `value` attribute of the `<input>`
 element as shown below:
 
-![logWhatIChange](../node_modules/can-debug/doc/what-i-change.png)
+<img class="bit-docs-screenshot" alt="logWhatIChange" src="../node_modules/can-debug/doc/what-i-change.png">
 
 @param {Object} observable An observable.
 @param {Any} [key] The key of a property on a map-like observable.


### PR DESCRIPTION
Closes #37 

```css
display: block; 
margin: 0 auto;
max-width: 100%;
```

These 3 rules make the images look so much better when resizing the window.

The image on the top has the styles applied while the one below does not and overflows:

![screen shot 2018-01-23 at 2 49 32 pm](https://user-images.githubusercontent.com/724877/35303128-1de84fea-004e-11e8-9081-fa5971f3db12.png)

Applying styles to both images:

![screen shot 2018-01-23 at 2 53 19 pm](https://user-images.githubusercontent.com/724877/35303148-2f5078de-004e-11e8-8326-23ec81852e3a.png)

Examples with different window size:

![screen shot 2018-01-23 at 2 53 25 pm](https://user-images.githubusercontent.com/724877/35303166-40cd24ea-004e-11e8-810c-e828a591984e.png)

![screen shot 2018-01-23 at 2 53 43 pm](https://user-images.githubusercontent.com/724877/35303168-44dcd6e8-004e-11e8-96ee-cc23bfa6d493.png)

![screen shot 2018-01-23 at 2 54 04 pm](https://user-images.githubusercontent.com/724877/35303175-4a2de088-004e-11e8-8196-613af5b25fe8.png)

