### PR TITLE
Use typeof to check for Proxy support

### DIFF
--- a/can-debug-test.js
+++ b/can-debug-test.js
@@ -14,23 +14,6 @@ QUnit.test("sets can global namespace", function(assert) {
 	assert.equal(typeof window.can, "object", "should set global namespace");
 });
 
-(Proxy != null ? QUnit.test : QUnit.skip)("warns users accessing global namespace once",
-	function(assert) {
-		var warn = console.warn;
-
-		assert.expect(1);
-		console.warn = function(msg) {
-			assert.ok(/for debugging purposes only/.test(msg));
-		};
-
-		var d = can.debug;
-		d = can.debug;
-		d = can.debug;
-
-		console.warn = warn;
-	}
-);
-
 QUnit.test("sets itself on the global namespace", function(assert) {
 	assert.equal(typeof can.debug, "object", "should set itself");
 });

--- a/can-debug.js
+++ b/can-debug.js
@@ -20,4 +20,4 @@ module.exports = namespace.debug = {
 	logWhatChangesMe: temporarilyBind(logWhatChangesMe)
 };
 
-window.can = Proxy != null ? proxyNamespace(namespace) : namespace;
+window.can = typeof Proxy !== "undefined" ? proxyNamespace(namespace) : namespace;


### PR DESCRIPTION
You can't do `Proxy != null` because if Proxy is not defined it will
cause a ReferenceError. `typeof` is the correct way to test for a
global.

This also removes the flawed warning test, which depends on nothing else
having accessed the can namespace before the test runs.