### PR TITLE
making sure __CANJS_DEVTOOLS__.register is called

### DIFF
--- a/can-debug-test.js
+++ b/can-debug-test.js
@@ -44,22 +44,61 @@ QUnit.test("calls canReflect bind symbols safely", function(assert) {
 testHelpers.dev.devOnlyTest("calls window.__CANJS_DEVTOOLS__.register if available", function(assert) {
 	var done = assert.async();
 
-	var devtools = window.__CANJS_DEVTOOLS__ = window.__CANJS_DEVTOOLS__ || {};
-
-	var origRegister = devtools.register;
-	devtools.register = function(can) {
-		assert.ok("Symbol" in can, "can.Symbol passed");
-		assert.ok("Reflect" in can, "can.Reflect passed");
-		assert.ok("queues" in can, "can.queues passed");
-		assert.ok("getGraph" in can, "can.getGraph passed");
-		assert.ok("formatGraph" in can, "can.formatGraph passed");
-		assert.ok("mergeDeep" in can, "can.mergeDeep passed");
+	var fakeWindow = {
+		__CANJS_DEVTOOLS__: {
+			register: function(can) {
+				assert.ok("Symbol" in can, "can.Symbol passed");
+				assert.ok("Reflect" in can, "can.Reflect passed");
+				assert.ok("queues" in can, "can.queues passed");
+				assert.ok("getGraph" in can, "can.getGraph passed");
+				assert.ok("formatGraph" in can, "can.formatGraph passed");
+				assert.ok("mergeDeep" in can, "can.mergeDeep passed");
+				done();
+			}
+		}
 	};
 
-	clone({})
+	clone({
+		"can-globals": {
+			default: {
+				getKeyValue: function(key) {
+					if (key === "global") {
+						return fakeWindow;
+					}
+				}
+			}
+		}
+	})
+	.import("can-debug");
+});
+
+testHelpers.dev.devOnlyTest("calls window.__CANJS_DEVTOOLS__.register if __CANJS_DEVTOOLS__ is set later", function(assert) {
+	var done = assert.async();
+	var fakeWindow = {};
+
+	clone({
+		"can-globals": {
+			default: {
+				getKeyValue: function(key) {
+					if (key === "global") {
+						return fakeWindow;
+					}
+				}
+			}
+		}
+	})
 	.import("can-debug")
 	.then(function() {
-		devtools.register = origRegister;
-		done();
+		fakeWindow.__CANJS_DEVTOOLS__ = {
+			register: function(can) {
+				assert.ok("Symbol" in can, "can.Symbol passed");
+				assert.ok("Reflect" in can, "can.Reflect passed");
+				assert.ok("queues" in can, "can.queues passed");
+				assert.ok("getGraph" in can, "can.getGraph passed");
+				assert.ok("formatGraph" in can, "can.formatGraph passed");
+				assert.ok("mergeDeep" in can, "can.mergeDeep passed");
+				done();
+			}
+		};
 	});
 });

--- a/can-debug.js
+++ b/can-debug.js
@@ -1,4 +1,5 @@
 var namespace = require("can-namespace");
+var globals = require("can-globals");
 var proxyNamespace = require("./src/proxy-namespace");
 var temporarilyBind = require("./src/temporarily-bind");
 
@@ -25,15 +26,26 @@ module.exports = namespace.debug = {
 	logWhatChangesMe: temporarilyBind(logWhatChangesMe)
 };
 
-window.can = typeof Proxy !== "undefined" ? proxyNamespace(namespace) : namespace;
+var global = globals.getKeyValue("global");
 
-if (window.__CANJS_DEVTOOLS__) {
-	window.__CANJS_DEVTOOLS__.register({
-		Symbol: canSymbol,
-		Reflect: canReflect,
-		queues: canQueues,
-		getGraph: namespace.debug.getGraph,
-		formatGraph: namespace.debug.formatGraph,
-		mergeDeep: mergeDeep
+global.can = typeof Proxy !== "undefined" ? proxyNamespace(namespace) : namespace;
+
+var devtoolsCanModules = {
+	Symbol: canSymbol,
+	Reflect: canReflect,
+	queues: canQueues,
+	getGraph: namespace.debug.getGraph,
+	formatGraph: namespace.debug.formatGraph,
+	mergeDeep: mergeDeep
+};
+
+if (global.__CANJS_DEVTOOLS__) {
+	global.__CANJS_DEVTOOLS__.register(devtoolsCanModules);
+} else {
+	Object.defineProperty(global, "__CANJS_DEVTOOLS__", {
+		set: function(devtoolsGlobal) {
+			devtoolsGlobal.register(devtoolsCanModules);
+			return devtoolsGlobal;
+		}
 	});
 }

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "can-diff": "^1.0.0",
+    "can-globals": "^1.0.0",
     "can-namespace": "1.0.0",
     "can-queues": "^1.0.0",
     "can-reflect": "^1.10.1",


### PR DESCRIPTION
This handles calling __CANJS_DEVTOOLS__.register if devtools script is
injected after `can-debug` has already loaded.

closes #48.