### PR TITLE
using can-assign instead of Object.assign (for IE11)

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     ]
   },
   "dependencies": {
+    "can-assign": "^1.3.1",
     "can-diff": "^1.0.0",
     "can-globals": "^1.0.0",
     "can-namespace": "1.0.0",

--- a/src/format-graph/format-graph.js
+++ b/src/format-graph/format-graph.js
@@ -1,5 +1,6 @@
 "use strict";
 var canReflect = require("can-reflect");
+var canAssign = require("can-assign");
 
 // Converts the graph into a data structure that vis.js requires to draw the graph
 module.exports = function formatGraph(graph) {
@@ -47,7 +48,7 @@ module.exports = function formatGraph(graph) {
 					var meta = graph.arrowsMeta.get(node).get(neighbor);
 
 					arrowsDataSet.push(
-						Object.assign(
+						canAssign(
 							{ from: headId, to: tailId },
 							getArrowData(meta)
 						)

--- a/src/graph/graph.js
+++ b/src/graph/graph.js
@@ -1,4 +1,6 @@
 "use strict";
+var canAssign = require("can-assign");
+
 function Graph() {
 	this.nodes = [];
 	this.arrows = new Map();
@@ -139,7 +141,7 @@ function addArrowMeta(graph, head, tail, meta) {
 		if (!arrowMeta) {
 			arrowMeta = {};
 		}
-		entry.set(tail, Object.assign(arrowMeta, meta));
+		entry.set(tail, canAssign(arrowMeta, meta));
 	} else {
 		entry = new Map();
 		entry.set(tail, meta);


### PR DESCRIPTION
closes https://github.com/canjs/can-debug/issues/60.